### PR TITLE
Add support for more complex metrics with bind 9.8

### DIFF
--- a/dns/ganglia_bind_stats.pl
+++ b/dns/ganglia_bind_stats.pl
@@ -7,6 +7,10 @@
 # NEED TO MODIFY FOLLOWING
 # Adjust this variables appropriately. Feel free to add any options to gmetric_command
 # necessary for running gmetric in your environment to gmetric_options e.g. -c /etc/gmond.conf
+
+# Forked by Benjamin Goodacre to work with bind 9.8
+# Handling of extraction of data needs tidying up, but works
+
 $gmetric_exec = "/usr/bin/gmetric";
 $gmetric_options = "-d 120 ";
 
@@ -17,24 +21,29 @@ $rndc_exec = "/usr/sbin/rndc";
 $tmp_dir_base="/var/named/chroot/tmp/bind_stats";
 
 # If you don't care about any of these particular metrics. Just remove them
+# Only metrics whose string is unique in the named_stats file are supported
 %counter_metrics = (
-	"success" => "req",
-	"referral" => "req",
-	"nxrrset" => "req",
-	"nxdomain" => "req",
-	"recursion" => "req",
-	"failure" => "req"
+  "IPv4 requests received" => "req",
+  "responses sent" => "req",
+  "queries resulted in successful answer" => "req",
+  "queries caused recursion" => "req",
+  "queries resulted in SERVFAIL" => "req",
+  "queries resulted in NXDOMAIN" => "req",
+  "queries with RTT < 10ms" => "req",
+  "queries with RTT 10-100ms" => "req",
+  "queries with RTT 100-500ms" => "req",
+  "queries with RTT 500-800ms" => "req",
 );
 
 $bind_stats = "/var/named/chroot/var/named/data/named_stats.txt";
 
 # DON"T TOUCH BELOW UNLESS YOU KNOW WHAT YOU ARE DOING
 if ( ! -x $gmetric_exec ) {
-	die("Gmetric binary is not executable. Exiting...");
+  die("Gmetric binary is not executable. Exiting...");
 }
 
 if ( ! -x $rndc_exec ) {
-	die("Rndc binary is not executable. Please check patch for \$rndc_exec. Exiting...");
+  die("Rndc binary is not executable. Please check patch for \$rndc_exec. Exiting...");
 }
 
 $gmetric_command = $gmetric_exec . " " . $gmetric_options;
@@ -54,8 +63,8 @@ if ( ! -d $tmp_dir_base ) {
 # it into a file. Don't do anything else
 ###############################################################################
 if ( ! -f $tmp_stats_file ) {
-	print "Creating baseline. No output this cycle\n";
-	system("echo '' > $bind_stats; $rndc_exec stats ; egrep '^[a-z]* [0-9]*\$' $bind_stats > $tmp_stats_file");
+  print "Creating baseline. No output this cycle\n";
+  system("echo '' > $bind_stats; $rndc_exec stats ; egrep '^[a-z]* [0-9]*\$' $bind_stats > $tmp_stats_file");
 } else {
 
 	######################################################
@@ -64,7 +73,9 @@ if ( ! -f $tmp_stats_file ) {
 	
 	while(<OLDSTATUS>)
 	{
-		($metric, $value) = split (/ /);
+		($blah, $value, $m1, $m2, $m3, $m4, $m5) = split (/\s+/);
+		$metric = $m1 . " " . $m2 . " " . $m3 . " " . $m4 . " " . $m5;
+		$metric =~ s/\s+$//;
 		$old_stats{$metric}=${value};
 	}
 	
@@ -75,13 +86,16 @@ if ( ! -f $tmp_stats_file ) {
 	#####################################################
 	# Get the new stats
 	#####################################################
-	system("echo > $bind_stats; $rndc_exec stats ; egrep '^[a-z]* [0-9]*\$' $bind_stats > $tmp_stats_file");
+	system("echo > $bind_stats; $rndc_exec stats ; grep '^\\s*[0-9]'   $bind_stats > $tmp_stats_file");
 	open(NEWSTATUS, "< $tmp_stats_file");
 	$new_time = time(); 
 	
 	while(<NEWSTATUS>)
 	{
-		($metric, $value) = split (/ /);
+		($blah, $value, $m1, $m2, $m3, $m4, $m5) = split (/\s+/);
+		$metric = $m1 . " " . $m2 . " " . $m3 . " " . $m4 . " " . $m5;
+		$metric =~ s/\s+$//;
+		#print "$metric is $new_stats{$metricn} = ${value}\n";
 		$new_stats{$metric}=${value};
 	}
 	close(NEWSTATUS);
@@ -94,20 +108,22 @@ if ( ! -f $tmp_stats_file ) {
 	
 	#################################################################################
 	# Calculate deltas for counter metrics and send them to ganglia
-	#################################################################################	
+	#################################################################################
 	while ( my ($metric, $units) = each(%counter_metrics) ) {
-		my $rate = ($new_stats{$metric} - $old_stats{$metric}) / $time_difference;
+	  my $rate = ($new_stats{$metric} - $old_stats{$metric}) / $time_difference;
 
-		if ( $rate < 0 ) {
-			print "Something is fishy. Rate for " . $metric . " shouldn't be negative. Perhaps counters were reset. Doing nothing";
-		} else {
-			print "$metric = $rate / sec\n";
-			if ( $debug == 0 ) {
-				system($gmetric_command . " -u '$units/sec' -tfloat -n dns_" . $metric . " -v " . $rate);
-			}
-			
-		}
-		
+	  if ( $rate < 0 ) {
+	    print "Something is fishy. Rate for " . $metric . " shouldn't be negative. Perhaps counters were reset. Doing nothing";
+	  } else {
+	    #print "$metric = $new_stats{$metric}    $rate / sec\n";
+	    if ( $debug == 0 ) {
+	print $metric . " old " . $old_stats{$metric} . " new " . $new_stats{$metric} . "\n";
+	   system($gmetric_command . " -g \"named_stats\" -u '$units/sec' -tfloat -n \"dns_" . $metric . "\" -v " . $rate);
+	    }
+	    
+	  }
+	  
 	}
 	
 }
+


### PR DESCRIPTION
Removed support for the older form of named_stats to allow it work with with 9.8. The handling of extraction of data is done badly, but it works.

Tested on 9.8.2rc1 (RedHat-9.8.2-0.47.rc1.el6)

Did some format tidying up.